### PR TITLE
feat: remove parameters.yml from .gitignore because it's needed for helm build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ charts/
 requirements.lock
 .DS_Store
 .idea
-parameters.yaml
 env/cluster/


### PR DESCRIPTION
Removing `parameters.yaml` from the `.gitignore` file because it's needed for `step helm build` in order to generate a valid `values.yml` file.