### PR TITLE
fix: install Ingress only if Application is enabled

### DIFF
--- a/env/templates/700-chartmuseum-ing.yaml
+++ b/env/templates/700-chartmuseum-ing.yaml
@@ -1,3 +1,4 @@
+{{- if index .Values "jenkins-x-platform" "chartmuseum" "enabled" }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -20,5 +21,6 @@ spec:
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-p"
 {{- else }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-s"
+{{- end }}
 {{- end }}
 {{- end }}

--- a/env/templates/700-hook-ing.yaml
+++ b/env/templates/700-hook-ing.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prow.enabled }}
+{{- if or .Values.prow.enabled .Values.lighthouse.enabled }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/env/templates/700-hook-ing.yaml
+++ b/env/templates/700-hook-ing.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.prow.enabled }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -25,5 +26,6 @@ spec:
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-p"
 {{- else }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-s"
+{{- end }}
 {{- end }}
 {{- end }}

--- a/env/templates/700-nexus-ing.yaml
+++ b/env/templates/700-nexus-ing.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nexus.enabled }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -20,5 +21,6 @@ spec:
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-p"
 {{- else }}
     secretName: "tls-{{ .Values.cluster.domain | replace "." "-" }}-s"
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
In the current version the `lighthouse` Ingress `hook` gets installed also when `lighthouse` is not enabled. 

I also added checks to the ingress of `nexus` and `chartmuseum` that they only will be created when they are enabled.