### PR TITLE
fix: change wrong  indentation at aks,aws,eks and gke kubeProviders

### DIFF
--- a/kubeProviders/aks/values.tmpl.yaml
+++ b/kubeProviders/aks/values.tmpl.yaml
@@ -1,12 +1,12 @@
 # Override configuration from https://github.com/jenkins-x/jenkins-x-platform/blob/master/jenkins-x-platform/values.yaml
+jenkins-x-platform:
+  PipelineSecrets:
 
-PipelineSecrets:
-
-  # lets enable ACR docker builds
-  DockerConfig: |-
-    {
-      "credsStore": "acr-linux"
-    }
+    # lets enable ACR docker builds
+    DockerConfig: |-
+      {
+        "credsStore": "acr-linux"
+      }
     
 docker-registry:
   enabled: false    

--- a/kubeProviders/aws/values.tmpl.yaml
+++ b/kubeProviders/aws/values.tmpl.yaml
@@ -1,9 +1,9 @@
 # Override configuration from https://github.com/jenkins-x/jenkins-x-platform/blob/master/jenkins-x-platform/values.yaml
+jenkins-x-platform:
+  PipelineSecrets:
 
-PipelineSecrets:
-
-  # lets enable ECR docker builds
-  DockerConfig: |-
-    {
-      "credsStore": "ecr-login"
-    }
+    # lets enable ECR docker builds
+    DockerConfig: |-
+      {
+        "credsStore": "ecr-login"
+      }

--- a/kubeProviders/eks/values.tmpl.yaml
+++ b/kubeProviders/eks/values.tmpl.yaml
@@ -1,12 +1,12 @@
 # Override configuration from https://github.com/jenkins-x/jenkins-x-platform/blob/master/jenkins-x-platform/values.yaml
+jenkins-x-platform:
+  PipelineSecrets:
 
-PipelineSecrets:
-
-  # lets enable ECR docker builds
-  DockerConfig: |-
-    {
-      "credsStore": "ecr-login"
-    }
-    
+    # lets enable ECR docker builds
+    DockerConfig: |-
+      {
+        "credsStore": "ecr-login"
+      }
+      
 docker-registry:
   enabled: false    

--- a/kubeProviders/gke/values.tmpl.yaml
+++ b/kubeProviders/gke/values.tmpl.yaml
@@ -1,7 +1,5 @@
 # Override configuration from https://github.com/jenkins-x/jenkins-x-platform/blob/master/jenkins-x-platform/values.yaml
 
-dockerRegistry: gcr.io
-
 jenkins-x-platform:
   dockerRegistry: gcr.io
 


### PR DESCRIPTION
The indentation in the aks,ews,eks and gke kubeProviders were not correct so the configuration there was not applied when `jx boot` was run. This PR fixes this issues.