### PR TITLE
feat: enable boot with helm build to use the versions resolver

### DIFF
--- a/env/Makefile
+++ b/env/Makefile
@@ -5,7 +5,7 @@ init:
 	helm repo add stable https://kubernetes-charts.storage.googleapis.com
 
 build: clean init
-	jx step helm build
+	jx step helm build --boot --provider-values-dir=../kubeProviders
 	helm lint .
 
 clean: 


### PR DESCRIPTION
After making sure the latest (v1.0.3) release of the versions stream has my fix for `jx step helm build` to use the versions stream, I'm changing the build command to be executed in boot mode with the kubeProviders directory being provided.

This will make the dev environment PullRequest to pass without failing after adding an app / quickstart.