### PR TITLE
fix: No longer need cert-manager ingress annotations

### DIFF
--- a/env/templates/700-hook-ing.yaml
+++ b/env/templates/700-hook-ing.yaml
@@ -5,11 +5,6 @@ metadata:
   name: hook
   annotations:
     kubernetes.io/ingress.class: nginx
-{{- if eq .Values.certmanager.production "true" }}
-    certmanager.k8s.io/issuer: letsencrypt-prod
-{{- else }}
-    certmanager.k8s.io/issuer: letsencrypt-staging
-{{- end }}
 spec:
   rules:
   - host: hook{{ .Values.cluster.namespaceSubDomain }}{{ .Values.cluster.domain }}


### PR DESCRIPTION
This is all done via the cert-manager issuer now.