### PR TITLE
WIP: fix: disable the pipeline k8s secret when vault is active

### DIFF
--- a/env/templates/gh-secret.yaml
+++ b/env/templates/gh-secret.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.JenkinsXGitHub.password }}
+{{- if and .Values.JenkinsXGitHub.password (eq .Values.vault.enabled false) }}
+apiVersion: v1
 apiVersion: v1
 data:
   password: {{ .Values.JenkinsXGitHub.password | b64enc | quote }}

--- a/env/values.tmpl.yaml
+++ b/env/values.tmpl.yaml
@@ -151,3 +151,11 @@ certmanager:
   enabled: false
 {{- end }}
 {{- end }}
+
+
+vault:
+{{- if eq .Requirements.secretStorage "vault" }}
+  enabled: true
+{{- else }}
+  enabled: false
+{{- end }}


### PR DESCRIPTION
The secrets should be fetched from vault directly instead of duplicating them into a k8s secrets.

Do not merge this yet because it will break the boot process. Some work is still required to configure
the git auth in vault prior to creating the environments.