### PR TITLE
Improve bash options

### DIFF
--- a/bdd/bdd.sh
+++ b/bdd/bdd.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 set -x
 
 if [ $# -ne 2 ]; then


### PR DESCRIPTION
Based on many hours of writing bash scripts - adding these options will make your scripts more predictable and robust.

I do not warrant these options will not blow things up badly in this case - just that they're generally a good idea - so rejecting this PR is totally cool.

See here for the longwinded explanation of the options - https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/