### PR TITLE
add option to set google project

### DIFF
--- a/systems/external-dns/values.tmpl.yaml
+++ b/systems/external-dns/values.tmpl.yaml
@@ -5,6 +5,9 @@ external-dns:
   provider: google
   google:
     serviceAccountSecret: external-dns-gcp-sa
+ {{ if .Requirements.cluster.project }}
+    project: "{{ .Requirements.cluster.project }}"
+ {{ end }}
   rbac:
     create: true
   domainFilters:


### PR DESCRIPTION
This matters if either you're not in GKE and don't have a Google Project, or you want to use another Google Project for the CloudDNS.

Signed-off-by: Joost van der Griendt <joostvdg@gmail.com>