### PR TITLE
fix: Turn on metapipeline by default

### DIFF
--- a/env/prow/values.tmpl.yaml
+++ b/env/prow/values.tmpl.yaml
@@ -15,7 +15,6 @@ pipelinerunner:
   args:
   - controller
   - pipelinerunner
-  - --use-meta-pipeline=false
 tillerNamespace: ""
 
 sinker:


### PR DESCRIPTION
We've been running with metapipeline on in prod for a week, and once
one fix went in a couple hours after we turned it on, we haven't seen
any further problems (and that problem wasn't metapipeline-specific
anyway), so let's turn on metapipeline by default.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>