### PR TITLE
fix: disable populating the docker cfg secret by default for IKS + PKS

### DIFF
--- a/kubeProviders/iks/values.tmpl.yaml
+++ b/kubeProviders/iks/values.tmpl.yaml
@@ -4,8 +4,7 @@ jenkins:
     Global:
       EnvVars:
         DOCKER_REGISTRY: "registry.ng.bluemix.net"
-# Smaller cluster configurations require more time   
-jenkins:
+  # Smaller cluster configurations require more time
   Master:
     Readiness:
       InitialDelaySeconds: 600
@@ -13,4 +12,10 @@ jenkins:
       InitialDelaySeconds: 660
       
 docker-registry:
-  enabled: false      
+  enabled: false
+
+jenkins-x-platform:
+  # lets disable creating the jenkins-x-docker-cfg secret
+  # we can manage that by hand for now
+  .PipelineSecrets:
+    DockerConfig: ""

--- a/kubeProviders/pks/values.tmpl.yaml
+++ b/kubeProviders/pks/values.tmpl.yaml
@@ -11,3 +11,9 @@ jenkins:
     # for PKS there is a different docker host path
     DockerHostPath: "/var/vcap/sys/run/docker/docker.sock"
     DockerMountPath: "/var/run/docker.sock"
+
+jenkins-x-platform:
+  # lets disable creating the jenkins-x-docker-cfg secret
+  # we can manage that by hand for now
+  .PipelineSecrets:
+    DockerConfig: ""


### PR DESCRIPTION
to avoid overwriting secrets created by hand via `jx create docker auth`