### PR TITLE
fix: verify-preinstall

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -45,7 +45,8 @@ pipelineConfig:
             - step
             - verify
             - preinstall
-            dir: /workspace/source/env
+            - --provider-values-dir="kubeProviders"
+            dir: /workspace/source
           - name: install-jx-crds
             command: jx
             args:


### PR DESCRIPTION
This change should address https://github.com/jenkins-x/jx/issues/5786 where preinstall is using the wrong kubeProviders directory.