### PR TITLE
fix: adding missing apiVersion to Helm Charts

### DIFF
--- a/env/Chart.yaml
+++ b/env/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 description: GitOps Environment for this Environment
 icon: https://www.cloudbees.com/sites/default/files/Jenkins_8.png
 maintainers:

--- a/repositories/Chart.yaml
+++ b/repositories/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 description: Source Repositories Chart
 maintainers:
 - name: Team

--- a/systems/vault/Chart.yaml
+++ b/systems/vault/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 description: Vault Chart
 maintainers:
 - name: Team


### PR DESCRIPTION
Using Helm 2.15.0, `jx boot` fails due to Helm Charts' missing property in some of the configuration's Charts. 