### PR TITLE
fix: external-dns values for provider EKS

### DIFF
--- a/systems/external-dns/values.tmpl.yaml
+++ b/systems/external-dns/values.tmpl.yaml
@@ -5,7 +5,7 @@ external-dns:
   provider: google
   google:
     serviceAccountSecret: external-dns-gcp-sa
- {{ if .Requirements.cluster.project }}
+ {{- if hasKey .Requirements.cluster "project" }}
     project: "{{ .Requirements.cluster.project }}"
  {{ end }}
   rbac:


### PR DESCRIPTION
## What?
In external-dns `systems/external-dns/values.tmpl.yaml`, check if the requirements file's cluster section has a key project defined instead of directly accessing it.

## Why?
In case of provider EKS, there is no such key as `project`, and `jx boot` fails in the pipeline step `install-external-dns`