### PR TITLE
fix: added velero configuration for iks

### DIFF
--- a/systems/velero/values.tmpl.yaml
+++ b/systems/velero/values.tmpl.yaml
@@ -35,5 +35,16 @@ velero:
       bucket: {{ .Requirements.storage.backup.url | removeScheme | quote }}
       config:
         storageAccount: {{ .Requirements.velero.serviceAccount | quote }}
+{{- else if eq .Requirements.cluster.provider "iks" }}
+  snapshotsEnabled: false
+  configuration:
+    provider: aws
+    backupStorageLocation:
+      name: aws
+      bucket: bucket-name
+      config:
+        region: {{ .Requirements.cluster.region | quote }}
+        s3ForcePathStyle: "true"
+        s3Url: {{ .Requirements.storage.backup.url | quote }}
 {{- end }}
 


### PR DESCRIPTION
This PR is adding the Velero configuration for IKS (IBM Cloud Kubernetes Service).
More information can be found at the following link: https://velero.io/docs/v1.1.0/ibm-config/

