### PR TITLE
fix: Indent docker credential

### DIFF
--- a/env/tekton/values.tmpl.yaml
+++ b/env/tekton/values.tmpl.yaml
@@ -14,12 +14,11 @@ auth:
     username: "{{ .Parameters.pipelineUser.username }}"
     password: "{{ .Parameters.pipelineUser.token }}"
     url: {{ .Requirements.cluster.gitServer | default "https://github.com" }}
-
 {{- if hasKey .Parameters "docker" }}
-docker:
-  username: "{{ .Parameters.docker.username }}"
-  password: "{{ .Parameters.docker.password }}"
-  url: "{{ .Parameters.docker.url }}"
+  docker:
+    username: "{{ .Parameters.docker.username }}"
+    password: "{{ .Parameters.docker.password }}"
+    url: "{{ .Parameters.docker.url }}"
 {{- end }}
 
 tillerNamespace: ""


### PR DESCRIPTION
In the parameters for jx boot there are interactive questions for [external docker registry](https://github.com/jenkins-x/jenkins-x-boot-config/blob/master/env/parameters.tmpl.schema.json#L107-L141). If I use a serverless flavor of Jenkins-x, then only empty docker config is mounted to each step as [declared here](https://github.com/jenkins-x/jenkins-x-platform/blob/master/jenkins-x-platform/values.yaml#L2363). The tekton pipeline has defined a [process to mount docker configuration](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker). The helm chart defined [those credential fields](https://github.com/jenkins-x-charts/tekton/blob/master/tekton/values.yaml#L18-L22). After the proposed change, the [docker secret](https://github.com/jenkins-x-charts/tekton/blob/master/tekton/templates/250-docker-secret.yaml) is mounted in the home directory of each tekton step. 