### PR TITLE
fix: disable build and plank microservices of prow

### DIFF
--- a/env/prow/values.tmpl.yaml
+++ b/env/prow/values.tmpl.yaml
@@ -18,4 +18,11 @@ pipelinerunner:
 tillerNamespace: ""
 
 sinker:
+  enabled: false
   replicaCount: 0
+
+build:
+  enabled: false
+
+plank:
+  enabled: false


### PR DESCRIPTION
This services are not used by the Jenkins X. 

fixes #https://github.com/jenkins-x/jx/issues/5980