### PR TITLE
fix: Add verify-fmt and fmt, fail PR if not formatted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+GO := GO111MODULE=off go
+
+install-fmt-deps:
+	$(GO) get github.com/abayer/fmt-yml-for-k8s
+
+fmt: install-fmt-deps
+	${GOPATH}/bin/fmt-yml-for-k8s --file jenkins-x.yml --output-dir .
+
+verify-fmt: install-fmt-deps fmt
+	$(eval CHANGED = $(shell git ls-files --modified --exclude-standard))
+	@if [ "$(CHANGED)" == "" ]; \
+		then \
+			echo "jenkins-x.yml properly formatted"; \
+		else \
+			echo "jenkins-x.yml is not properly formatted"; \
+			echo "$(CHANGED)"; \
+			git diff; \
+			exit 1; \
+		fi
+

--- a/jenkins-x-bdd-local.yml
+++ b/jenkins-x-bdd-local.yml
@@ -46,6 +46,8 @@ pipelineConfig:
                   - mountPath: /secrets
                     name: sa
             steps:
+              - name: verify-fmt
+                command: make verify-fmt
               - name: run-bdd
                 command: bdd/bdd.sh
                 args: ['bdd/boot-local', 'bdd-config']

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -8,20 +8,20 @@ pipelineConfig:
         stages:
         - name: pr-checks
           steps:
-          - name: verify-parameters
-            command: jx
-            args:
+          - args:
             - step
             - verify
             - values
             - --values-file=parameters.yaml
             - --schema-file=parameters.tmpl.schema.json
+            command: jx
             dir: /workspace/source/env
-          - name: lint-env-helm
-            command: make
-            args:
+            name: verify-parameters
+          - args:
             - build
+            command: make
             dir: /workspace/source/env
+            name: lint-env-helm
     release:
       pipeline:
         agent:
@@ -32,29 +32,27 @@ pipelineConfig:
         stages:
         - name: release
           steps:
-          - name: validate-git
-            command: jx
-            args:
+          - args:
             - step
             - git
             - validate
-            dir: /workspace/source/env
-          - name: verify-preinstall
             command: jx
-            args:
+            dir: /workspace/source/env
+            name: validate-git
+          - args:
             - step
             - verify
             - preinstall
             - --provider-values-dir="kubeProviders"
-            dir: /workspace/source
-          - name: install-jx-crds
             command: jx
-            args:
+            dir: /workspace/source
+            name: verify-preinstall
+          - args:
             - upgrade
             - crd
-          - name: install-velero
             command: jx
-            args:
+            name: install-jx-crds
+          - args:
             - step
             - helm
             - apply
@@ -63,13 +61,13 @@ pipelineConfig:
             - --no-vault
             - --name
             - velero
+            command: jx
             dir: /workspace/source/systems/velero
             env:
             - name: DEPLOY_NAMESPACE
               value: velero
-          - name: install-velero-backups
-            command: jx
-            args:
+            name: install-velero
+          - args:
             - step
             - helm
             - apply
@@ -78,13 +76,13 @@ pipelineConfig:
             - --no-vault
             - --name
             - velero-backups
+            command: jx
             dir: /workspace/source/systems/velero-backups
             env:
             - name: DEPLOY_NAMESPACE
               value: velero
-          - name: install-nginx-controller
-            command: jx
-            args:
+            name: install-velero-backups
+          - args:
             - step
             - helm
             - apply
@@ -93,22 +91,22 @@ pipelineConfig:
             - --no-vault
             - --name
             - jxing
+            command: jx
             dir: /workspace/source/systems/jxing
             env:
             - name: DEPLOY_NAMESPACE
               value: kube-system
-          - name: create-install-values
-            command: jx
-            args:
+            name: install-nginx-controller
+          - args:
             - step
             - create
             - install
             - values
             - -b
-            dir: /workspace/source/env
-          - name: install-external-dns
             command: jx
-            args:
+            dir: /workspace/source/env
+            name: create-install-values
+          - args:
             - step
             - helm
             - apply
@@ -117,22 +115,22 @@ pipelineConfig:
             - --no-vault
             - --name
             - exdns
+            command: jx
             dir: /workspace/source/systems/external-dns
-          - name: install-cert-manager-crds
-            command: kubectl
-            args:
+            name: install-external-dns
+          - args:
             - apply
             - --wait
             - --validate=true
             - -f
             - https://raw.githubusercontent.com/jetstack/cert-manager/release-0.8/deploy/manifests/00-crds.yaml
+            command: kubectl
             dir: /workspace/source
             env:
             - name: DEPLOY_NAMESPACE
               value: cert-manager
-          - name: install-cert-manager
-            command: jx
-            args:
+            name: install-cert-manager-crds
+          - args:
             - step
             - helm
             - apply
@@ -141,13 +139,13 @@ pipelineConfig:
             - --no-vault
             - --name
             - cm
+            command: jx
             dir: /workspace/source/systems/cm
             env:
             - name: DEPLOY_NAMESPACE
               value: cert-manager
-          - name: install-acme-issuer-and-certificate
-            command: jx
-            args:
+            name: install-cert-manager
+          - args:
             - step
             - helm
             - apply
@@ -156,26 +154,26 @@ pipelineConfig:
             - --no-vault
             - --name
             - acme
-            dir: /workspace/source/systems/acme
-          - name: install-vault
             command: jx
-            args:
+            dir: /workspace/source/systems/acme
+            name: install-acme-issuer-and-certificate
+          - args:
             - step
             - boot
             - vault
-            dir: /workspace/source/systems/vault
-          - name: create-helm-values
             command: jx
-            args:
+            dir: /workspace/source/systems/vault
+            name: install-vault
+          - args:
             - step
             - create
             - values
             - --name
             - parameters
-            dir: /workspace/source/env
-          - name: install-jenkins-x
             command: jx
-            args:
+            dir: /workspace/source/env
+            name: create-helm-values
+          - args:
             - step
             - helm
             - apply
@@ -185,47 +183,49 @@ pipelineConfig:
             - jenkins-x
             - --provider-values-dir
             - ../kubeProviders
-            dir: /workspace/source/env
-          - name: verify-jenkins-x-environment
             command: jx
-            args:
+            dir: /workspace/source/env
+            name: install-jenkins-x
+          - args:
             - step
             - verify
             - env
-            dir: /workspace/source
-          - name: install-repositories
             command: jx
-            args:
+            dir: /workspace/source
+            name: verify-jenkins-x-environment
+          - args:
             - step
             - helm
             - apply
             - --boot
             - --name
             - repos
-            dir: /workspace/source/repositories
-          - name: install-pipelines
             command: jx
-            args:
+            dir: /workspace/source/repositories
+            name: install-repositories
+          - args:
             - step
             - scheduler
             - config
             - apply
             - --direct=true
-            dir: /workspace/source/prowConfig
-          - name: update-webhooks
             command: jx
-            args:
+            dir: /workspace/source/prowConfig
+            name: install-pipelines
+          - args:
             - update
             - webhooks
             - --verbose
             - --warn-on-fail
-            dir: /workspace/source/repositories
-          - name: verify-installation
             command: jx
-            args:
+            dir: /workspace/source/repositories
+            name: update-webhooks
+          - args:
             - step
             - verify
             - install
             - --pod-wait-time
             - 30m
+            command: jx
             dir: /workspace/source/env
+            name: verify-installation


### PR DESCRIPTION
This is a first attempt to solve some of the problems we get hit with
relating to merging `jenkins-x.yml`, mandating that `jenkins-x.yml` is
consistently formatted (by using a little utility I wrote that reads
in the file and outputs it again via marshalling with `sigs.k8s.io/yaml`).

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>