### PR TITLE
feat: pks configuration to use dockerhub as default provider and mount local secrets as a volume

### DIFF
--- a/env/parameters.tmpl.schema.json
+++ b/env/parameters.tmpl.schema.json
@@ -99,6 +99,9 @@
     "enableDocker": {
       "type": "boolean",
       "title": "Do you want to configure an external Docker Registry?",
+{{- if and (ne .Requirements.cluster.provider "gke") (ne .Requirements.cluster.provider "eks") (ne .Requirements.cluster.provider "aks") }}
+      "const": true,
+{{- end}}
       "description": "By default Jenkins X will use the docker registry from the cloud provider. If you want to configure an external docker registry such as Docker Hub or your own existing docker registry enter Y"
     }
   },
@@ -107,7 +110,7 @@
       "if": {
         "properties": {
           "enableDocker": {
-            "const": "true",
+            "const": true,
             "type": "boolean"
           }
         }
@@ -119,7 +122,8 @@
             "required": [
               "url",
               "username",
-              "password"
+              "password",
+              "email"
             ],
             "properties": {
               "url": {
@@ -139,6 +143,11 @@
                 "format": "password",
                 "title": "Docker Registry password",
                 "description": "The password used to access the external docker registry"
+              },
+              "email": {
+                "type": "string",
+                "title": "Docker Registry email",
+                "description": "The email used to configure the external docker registry"
               }
             }
           }

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -7,6 +7,17 @@ pipelineConfig:
           image: gcr.io/jenkinsxio/builder-go
         stages:
         - name: pr-checks
+          options:
+            containerOptions:
+              volumeMounts:
+              - mountPath: /builder/home/.jx/localSecrets/currentCluster
+                name: local-secrets
+                readOnly: true
+            volumes:
+            - name: local-secrets
+              secret:
+                optional: true
+                secretName: local-param-secrets
           steps:
           - args:
             - step
@@ -31,6 +42,17 @@ pipelineConfig:
           value: jx
         stages:
         - name: release
+          options:
+            containerOptions:
+              volumeMounts:
+              - mountPath: /builder/home/.jx/localSecrets/currentCluster
+                name: local-secrets
+                readOnly: true
+            volumes:
+            - name: local-secrets
+              secret:
+                optional: true
+                secretName: local-param-secrets
           steps:
           - args:
             - step

--- a/kubeProviders/pks/values.tmpl.yaml
+++ b/kubeProviders/pks/values.tmpl.yaml
@@ -6,3 +6,19 @@ jenkins:
     DockerHostPath: "/var/vcap/sys/run/docker/docker.sock"
     DockerMountPath: "/var/run/docker.sock"
 
+jenkins-x-platform:
+  PipelineSecrets:
+{{- if eq .Parameters.enableDocker true }}
+    DockerConfig: |-
+      {
+        "auths":{
+          {{ .Parameters.docker.url | quote }}:
+            {
+              "auth": {{ printf "%s:%s" .Parameters.docker.username .Parameters.docker.password | b64enc | quote}},
+              "email": {{ .Parameters.docker.email | quote}}
+            }
+        }
+      }
+{{- else}}
+    DockerConfig: ""
+{{- end}}


### PR DESCRIPTION
Some PKS configuration to use configure an external Docker registry by default and some logic to mount local secrets as an optional volume when booting with local secrets enabled instead of Vault.