### PR TITLE
feat: configuration for cert-manager in EKS and new APIs for the new versions

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -143,9 +143,9 @@ pipelineConfig:
           - args:
             - apply
             - --wait
-            - --validate=true
+            - --validate=false
             - -f
-            - https://raw.githubusercontent.com/jetstack/cert-manager/release-0.8/deploy/manifests/00-crds.yaml
+            - https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/deploy/manifests/00-crds.yaml
             command: kubectl
             dir: /workspace/source
             env:

--- a/kubeProviders/eks/templates/irsa.tmpl.yaml
+++ b/kubeProviders/eks/templates/irsa.tmpl.yaml
@@ -16,6 +16,28 @@ iam:
     attachPolicyARNs:
     - {{.IAM.TektonBotPolicy | quote}}
 {{- end }}
+{{- if .IAM.ExternalDNSPolicy }}
+  - metadata:
+      name: exdns-external-dns
+      namespace: jx
+      labels: {aws-usage: "jenkins-x"}
+    attachPolicyARNs:
+    - {{.IAM.ExternalDNSPolicy | quote}}
+{{- end }}
+{{- if .IAM.CertManagerPolicy }}
+  - metadata:
+      name: cm-cert-manager
+      namespace: cert-manager
+      labels: {aws-usage: "jenkins-x"}
+    attachPolicyARNs:
+    - {{.IAM.CertManagerPolicy | quote}}
+  - metadata:
+      name: cm-cainjector
+      namespace: cert-manager
+      labels: {aws-usage: "jenkins-x"}
+    attachPolicyARNs:
+    - {{.IAM.CertManagerPolicy | quote}}
+{{- end }}
   - metadata:
       name: jenkins-x-controllerbuild
       namespace: jx

--- a/kubeProviders/eks/templates/jenkinsx-policies.yml
+++ b/kubeProviders/eks/templates/jenkinsx-policies.yml
@@ -3,7 +3,7 @@ Resources:
   CFNJenkinsXPolicies:
     Type: AWS::IAM::ManagedPolicy
     Properties:
-      ManagedPolicyName: !Join [ "-", [ CNFTektonBotPolicy, Ref: PoliciesSuffixParameter] ] 
+      ManagedPolicyName: !Join [ "-", [ CFNTektonBotPolicy, Ref: PoliciesSuffixParameter] ]
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -14,15 +14,49 @@ Resources:
           - cloudformation:CreateStack
           - cloudformation:DeleteStack
           - eks:*
-          - s3:*
           - iam:DetachRolePolicy
           - iam:GetPolicy
           - iam:CreatePolicy
           - iam:DeleteRole
           - iam:GetOpenIDConnectProvider
           Resource: "*"
-Parameters: 
-  PoliciesSuffixParameter: 
+  CFNExternalDNSPolicies:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Join [ "-", [ CFNExternalDNSPolicy, Ref: PoliciesSuffixParameter] ]
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action:
+          - route53:ChangeResourceRecordSets
+          Resource: "arn:aws:route53:::hostedzone/*"
+        - Effect: Allow
+          Action:
+          - route53:ListHostedZones
+          - route53:ListResourceRecordSets
+          Resource: "*"
+  CFNCertManagerPolicies:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Join [ "-", [ CFNCertManagerPolicy, Ref: PoliciesSuffixParameter] ]
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action:
+          - route53:GetChange
+          Resource: "arn:aws:route53:::change/*"
+        - Effect: Allow
+          Action:
+          - route53:ChangeResourceRecordSets
+          Resource: "arn:aws:route53:::hostedzone/*"
+        - Effect: Allow
+          Action:
+          - route53:ListHostedZonesByName
+          Resource: "*"
+Parameters:
+  PoliciesSuffixParameter:
     Type: String
     Description: A suffix so we can create different policies on each execution
 Outputs:
@@ -31,4 +65,16 @@ Outputs:
       Ref: CFNJenkinsXPolicies
     Description: The ARN of the created policy
     Export:
-      Name: !Join [ "-", [ TektonBotPolicy, Ref: PoliciesSuffixParameter] ] 
+      Name: !Join [ "-", [ TektonBotPolicy, Ref: PoliciesSuffixParameter] ]
+  CFNExternalDNSPolicy:
+    Value:
+      Ref: CFNExternalDNSPolicies
+    Description: The ARN of the created policy
+    Export:
+      Name: !Join [ "-", [ ExternalDNSPolicy, Ref: PoliciesSuffixParameter] ]
+  CFNCertManagerPolicy:
+    Value:
+      Ref: CFNCertManagerPolicies
+    Description: The ARN of the created policy
+    Export:
+      Name: !Join [ "-", [ CertManagerPolicy, Ref: PoliciesSuffixParameter] ]

--- a/systems/acme/templates/cert-manager-prod-certificate.yaml
+++ b/systems/acme/templates/cert-manager-prod-certificate.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.certmanager.enabled }}
 {{- if eq .Values.certmanager.production "true" }}
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: "tls-{{ .Values.cluster.domain | replace "." "-" }}-p"

--- a/systems/acme/templates/cert-manager-prod-issuer.yaml
+++ b/systems/acme/templates/cert-manager-prod-issuer.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.certmanager.enabled }}
 {{- if eq .Values.certmanager.production "true" }}
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: letsencrypt-prod
@@ -18,6 +18,7 @@ spec:
         - "{{ .Values.cluster.domain }}"
       # ACME DNS-01 provider configurations
       dns01:
+{{- if eq .Values.cluster.provider "gke" }}
         clouddns:
           # The project in which to update the DNS zone
           project: "{{ .Values.cluster.projectID }}"
@@ -25,5 +26,10 @@ spec:
           serviceAccountSecretRef:
             name: external-dns-gcp-sa
             key: credentials.json
+{{- end }}
+{{- if eq .Values.cluster.provider "eks" }}
+        route53:
+          region: {{ .Values.cluster.region }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/systems/acme/templates/cert-manager-staging-certificate.yaml
+++ b/systems/acme/templates/cert-manager-staging-certificate.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.certmanager.enabled }}
 {{- if eq .Values.certmanager.production "false" }}
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: "tls-{{ .Values.cluster.domain | replace "." "-" }}-s"

--- a/systems/acme/templates/cert-manager-staging-issuer.yaml
+++ b/systems/acme/templates/cert-manager-staging-issuer.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.certmanager.enabled }}
 {{- if eq .Values.certmanager.production "false" }}
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: letsencrypt-staging
@@ -18,6 +18,7 @@ spec:
         - "{{ .Values.cluster.domain }}"
       # ACME DNS-01 provider configurations
       dns01:
+{{- if eq .Values.cluster.provider "gke" }}
         clouddns:
           # The project in which to update the DNS zone
           project: "{{ .Values.cluster.projectID }}"
@@ -25,6 +26,11 @@ spec:
           serviceAccountSecretRef:
             name: external-dns-gcp-sa
             key: credentials.json
+{{- end }}
+{{- if eq .Values.cluster.provider "eks" }}
+        route53:
+          region: {{ .Values.cluster.region }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/systems/acme/values.tmpl.yaml
+++ b/systems/acme/values.tmpl.yaml
@@ -1,9 +1,15 @@
 cluster:
   domain: {{ .Requirements.ingress.domain }}
+  provider: {{ .Requirements.cluster.provider }}
 {{- if hasKey .Requirements.cluster "project" }}
   projectID: {{ .Requirements.cluster.project }}
 {{- else }}
   projectID: ""
+{{- end }}
+{{- if hasKey .Requirements.cluster "region" }}
+  region: {{ .Requirements.cluster.region }}
+{{- else }}
+  region: ""
 {{- end }}
 
  {{- if .Requirements.ingress.tls }}

--- a/systems/cm/values.tmpl.yaml
+++ b/systems/cm/values.tmpl.yaml
@@ -1,8 +1,16 @@
 cert-manager:
   enabled: {{ .Requirements.ingress.tls.enabled }}
+{{- if eq .Requirements.cluster.provider "eks" }}
+  extraArgs:
+    - --issuer-ambient-credentials
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+{{- end }}
   rbac:
     create: true
   webhook:
     enabled: false
+    
 webhook:
   enabled: false

--- a/systems/external-dns/values.tmpl.yaml
+++ b/systems/external-dns/values.tmpl.yaml
@@ -2,12 +2,21 @@ external-dns:
   enabled: {{ .Requirements.ingress.externalDNS }}
   sources:
   - ingress
+{{- if eq .Requirements.cluster.provider "eks"}}
+  provider: aws
+  aws:
+    region: {{ .Requirements.cluster.region}}
+  securityContext:
+    fsGroup: 65534
+{{- else if eq .Requirements.cluster.provider "gke"}}
   provider: google
   google:
     serviceAccountSecret: external-dns-gcp-sa
  {{- if hasKey .Requirements.cluster "project" }}
     project: "{{ .Requirements.cluster.project }}"
  {{ end }}
+{{- end}}
+
   rbac:
     create: true
   domainFilters:


### PR DESCRIPTION
New configuration for cert-manager and external dns for EKS.

Also, migration of the ACME certificates and issuers to the new API.