### PR TITLE
fix: Fill mandatory tls field for jxboot chart

### DIFF
--- a/env/jxboot-resources/values.tmpl.yaml
+++ b/env/jxboot-resources/values.tmpl.yaml
@@ -19,6 +19,8 @@ cluster:
   serverUrl: ""
 {{- if .Requirements.ingress.tls.enabled }}
   tls: true
+{{- else }}
+  tls: false
 {{- end }}
 
 gitops:


### PR DESCRIPTION
#### Description

I found a problem when I tested boot configuration with tls disabled. The step install-jenkins-x with environment variable JX_HELM3 set to true resulted with error: `unable to build kubernetes objects from release manifest: error validating "": error validating data: unknown object type "nil" in ConfigMap.data.tls`.

The filed is located in [ingress-configmap](https://github.com/jenkins-x-charts/jxboot-resources/blob/master/jxboot-resources/templates/ingress-config-configmap.yaml#L7).

#### Special notes for the reviewer(s)

The helm just released version 3.0.0 which causes few problems with the `jx boot` command. Maybe `tls: false` should be placed in the corresponding [default values](https://github.com/jenkins-x-charts/jxboot-resources/blob/master/jxboot-resources/values.yaml#L11). Or the solution should look like `tls: .Requirements.ingress.tls.enabled`, because standard behavior of jx boot command will default to tls false as per [ingress doc](https://github.com/jenkins-x/jx-docs/blame/master/content/en/docs/getting-started/setup/boot/_index.md#L439)
