### PR TITLE
fix: use NLB for jxing in AWS

### DIFF
--- a/systems/jxing/values.tmpl.yaml
+++ b/systems/jxing/values.tmpl.yaml
@@ -5,6 +5,10 @@ nginx-ingress:
       publish-service: kube-system/jxing-nginx-ingress-controller
     service:
       omitClusterIP: true
+{{- if eq .Requirements.cluster.provider "eks" }}
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-type: nlb
+{{- end }}
   defaultBackend:
     service:
       omitClusterIP: true


### PR DESCRIPTION
fix jenkins-x/jx#5790