### PR TITLE
fix: generate the jx auth config in a config map which references the git pipeline secret from vault

### DIFF
--- a/env/jxboot-resources/values.tmpl.yaml
+++ b/env/jxboot-resources/values.tmpl.yaml
@@ -181,3 +181,11 @@ prow:
 {{- else }}
   enabled: false
 {{- end }}
+
+vault:
+{{- if eq .Requirements.secretStorage "vault" }}
+  enabled: true
+{{- else }}
+  enabled: false
+{{- end }}
+

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -201,8 +201,8 @@ pipelineConfig:
             - step
             - create
             - templated
-            - --parameters-file=../../env/parameters.yaml
-            - --requirements-dir=../../
+            - --parameters-file=/workspace/source/env/parameters.yaml
+            - --requirements-dir=/workspace/source/
             - --template-file=jx-auth-configmap.tmpl.yaml
             - --config-file=templates/jx-auth-configmap.yaml
             command: jx

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -199,6 +199,29 @@ pipelineConfig:
             name: create-helm-values
           - args:
             - step
+            - create
+            - templated
+            - --parameters-file=../../env/parameters.yaml
+            - --requirements-dir=../../
+            - --template-file=jx-auth-configmap.tmpl.yaml
+            - --config-file=templates/jx-auth-configmap.yaml
+            command: jx
+            dir: /workspace/source/systems/jx-auth
+            name: create-jx-auth-config
+          - args:
+            - step
+            - helm
+            - apply
+            - --boot
+            - --remote
+            - --no-vault
+            - --name
+            - jx-auth
+            command: jx
+            dir: /workspace/source/systems/jx-auth
+            name: install-jx-auth-config
+          - args:
+            - step
             - helm
             - apply
             - --boot

--- a/systems/jx-auth/Chart.yaml
+++ b/systems/jx-auth/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+description: Jx Auth Chart
+maintainers:
+- name: Team
+name: jx-auth
+version: "1"

--- a/systems/jx-auth/jx-auth-configmap.tmpl.yaml
+++ b/systems/jx-auth/jx-auth-configmap.tmpl.yaml
@@ -1,0 +1,24 @@
+{{- if eq .Requirements.secretStorage "vault" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jx-auth-config
+  labels:
+    jenkins.io/created-by: jx
+    jenkins.io/config-type: auth
+data:
+  gitAuth.yaml: |
+    currentserver: "{{ .Requirements.cluster.gitServer }}"
+    defaultusername: "{{ .Parameters.pipelineUser.username }}"
+    pipelineserver: "{{ .Requirements.cluster.gitServer }}"
+    pipelineusername: "{{ .Parameters.pipelineUser.username }}"
+    servers:
+    - currentuser: "{{ .Parameters.pipelineUser.username }}"
+      kind: "{{ .Requirements.cluster.gitKind }}"
+      name: "{{ .Requirements.cluster.gitName }}"
+      url: "{{ .Requirements.cluster.gitServer }}"
+      users:
+      - apitoken: "{{ .Parameters.pipelineUser.token }}"
+        bearertoken: ""
+        username: "{{ .Parameters.pipelineUser.username }}"
+{{- end }}

--- a/systems/jx-auth/templates/jx-auth-configmap.yaml
+++ b/systems/jx-auth/templates/jx-auth-configmap.yaml
@@ -1,0 +1,1 @@
+# This jx auth configmap will be generated from template


### PR DESCRIPTION
Also disable the git auth pipeline secret when vault is enabled. This will allow us to avoid duplicating
the git bot token in multiple places. jx will fetch dynamically the token from vault into memory whenever
it needs to authenticate.

The generated and installed config map looks like this:

```
apiVersion: v1
data:
  gitAuth.yaml: |
    currentserver: "https://github.com"
    defaultusername: "ccojocar-bot"
    pipelineserver: "https://github.com"
    pipelineusername: "ccojocar-bot"
    servers:
    - currentuser: "bot-user"
      kind: "github"
      name: "github"
      url: "https://github.com"
      users:
      - apitoken: "vault:cluster-name/pipelineUser:token"
        bearertoken: ""
        username: "bot-user"
kind: ConfigMap
metadata:
  annotations:
    jenkins.io/chart: jx-auth
```
fixes https://github.com/jenkins-x/jx/issues/5114