### PR TITLE
fix: Only use docker-credential-ecr-login for ecr

### DIFF
--- a/kubeProviders/eks/values.tmpl.yaml
+++ b/kubeProviders/eks/values.tmpl.yaml
@@ -5,7 +5,13 @@ jenkins-x-platform:
     # lets enable ECR docker builds
     DockerConfig: |-
       {
+{{- if .Requirements.cluster.registry }}
+        "credHelpers": {
+          "{{ .Requirements.cluster.registry }}": "ecr-login"
+        }
+{{- else }}
         "credsStore": "ecr-login"
+{{- end }}
       }
       
 docker-registry:


### PR DESCRIPTION
This fixes the problem that exist in EKS version 1.13 and 1.14 with building docker images with a base image that isn't situated in ecr.

Fixes jenkins-x/jx#4501