### PR TITLE
feat: support environments domains for exdns controller

### DIFF
--- a/systems/external-dns/values.tmpl.yaml
+++ b/systems/external-dns/values.tmpl.yaml
@@ -11,4 +11,11 @@ external-dns:
   rbac:
     create: true
   domainFilters:
+# add default ingress domain  
   - "{{ .Requirements.ingress.domain }}"
+# loop over environments' ingresses and add each domain
+{{- range .Requirements.environments }}
+  {{- if .ingress.domain }}
+  - "{{ .ingress.domain }}"
+  {{- end }}
+{{- end }}

--- a/systems/external-dns/values.tmpl.yaml
+++ b/systems/external-dns/values.tmpl.yaml
@@ -11,8 +11,6 @@ external-dns:
   rbac:
     create: true
   domainFilters:
-# add default ingress domain  
-  - "{{ .Requirements.ingress.domain }}"
 # loop over environments' ingresses and add each domain
 {{- range .Requirements.environments }}
   {{- if .ingress.domain }}


### PR DESCRIPTION
the exdns controller can take multiple domain filters as an argument.
if a user wants to define unique domain names for different environments, they need to be explicitly configured as a separate domain filter.

Signed-off-by: Joost van der Griendt <joostvdg@gmail.com>