### PR TITLE
fix: generate the jx auth config in a config map which references the git pipeline secret from vault

### DIFF
--- a/bdd/boot-vault/README.md
+++ b/bdd/boot-vault/README.md
@@ -1,0 +1,1 @@
+## BDD test using JX Boot with Vault secrets

--- a/bdd/boot-vault/cluster.yaml
+++ b/bdd/boot-vault/cluster.yaml
@@ -1,0 +1,18 @@
+clusters:
+  - name: boot-vault
+    args:
+      - create
+      - cluster
+      - gke
+      - --project-id=jenkins-x-bdd3
+      - -m=n1-standard-2
+      - --min-num-nodes=3
+      - --max-num-nodes=5
+      - -z=europe-west1-c
+      - --skip-login
+      - --skip-installation
+    commands:
+      - command: jx
+        args:
+          - boot
+          - -b

--- a/bdd/boot-vault/jx-requirements.yml
+++ b/bdd/boot-vault/jx-requirements.yml
@@ -1,0 +1,40 @@
+cluster:
+  clusterName: bdd-boot-vault
+  environmentGitOwner: jenkins-x-bot-test
+  project: jenkins-x-bdd3
+  provider: gke
+  zone: europe-west1-c
+environments:
+  - key: dev
+    owner: ""
+    repository: ""
+  - key: staging
+    owner: ""
+    repository: ""
+  - key: production
+    owner: ""
+    repository: ""
+ingress:
+  domain: ""
+  externalDNS: false
+  tls:
+    email: ""
+    enabled: false
+    production: false
+kaniko: true
+secretStorage: vault
+storage:
+  logs:
+    enabled: false
+    url: ""
+  reports:
+    enabled: false
+    url: ""
+  repository:
+    enabled: false
+    url: ""
+versionStream:
+  ref: "master"
+  url: https://github.com/jenkins-x/jenkins-x-versions.git
+webhook: prow
+

--- a/bdd/boot-vault/jx-requirements.yml
+++ b/bdd/boot-vault/jx-requirements.yml
@@ -23,6 +23,7 @@ ingress:
     production: false
 kaniko: true
 secretStorage: vault
+repository: nexus
 storage:
   logs:
     enabled: false
@@ -36,5 +37,7 @@ storage:
 versionStream:
   ref: "master"
   url: https://github.com/jenkins-x/jenkins-x-versions.git
+vault:
+  disableURLDiscovery: true
 webhook: prow
 

--- a/bdd/boot-vault/parameters.yaml
+++ b/bdd/boot-vault/parameters.yaml
@@ -1,0 +1,10 @@
+adminUser:
+  username: admin
+enableDocker: false
+gitProvider: github
+gpg: {}
+pipelineUser:
+  github:
+    host: github.com
+    username: jenkins-x-bot-test
+    email: jenkins-x@googlegroups.com

--- a/env/jxboot-resources/values.tmpl.yaml
+++ b/env/jxboot-resources/values.tmpl.yaml
@@ -181,3 +181,10 @@ prow:
 {{- else }}
   enabled: false
 {{- end }}
+
+vault:
+{{- if eq .Requirements.secretStorage "vault" }}
+  enabled: true
+{{- else }}
+  enabled: false
+{{- end }}

--- a/jenkins-x-bdd-vault.yml
+++ b/jenkins-x-bdd-vault.yml
@@ -1,0 +1,52 @@
+pipelineConfig:
+  pipelines:
+    pullRequest:
+      pipeline:
+        options:
+          containerOptions:
+            resources:
+              limits:
+                cpu: 4
+                memory: 6144Mi
+              requests:
+                cpu: 1
+                memory: 2048Mi
+        environment:
+          - name: GOPROXY
+            value: http://jenkins-x-athens-proxy:80
+          - name: GKE_SA
+            value: /secrets/bdd/sa.json
+          - name: DOMAIN_ROTATION
+            value: "false"
+          - name: GH_ACCESS_TOKEN 
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-x-bot-test-github
+                key: password
+          - name: JENKINS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-jenkins-user 
+                key: password
+        agent:
+          image: gcr.io/jenkinsxio/builder-go-maven
+        stages:
+          - name: ci
+            options:
+              volumes:
+                - name: sa
+                  secret:
+                    secretName: bdd-secret
+                    items:
+                      - key: bdd-credentials.json
+                        path: bdd/sa.json
+              containerOptions:
+                volumeMounts:
+                  - mountPath: /secrets
+                    name: sa
+            steps:
+              - name: verify-fmt
+                command: make verify-fmt
+              - name: run-bdd
+                command: bdd/bdd.sh
+                args: ['bdd/boot-vault', 'bdd-config']

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -199,6 +199,29 @@ pipelineConfig:
             name: create-helm-values
           - args:
             - step
+            - create
+            - templated
+            - --parameters-file=./workspace/source/env/parameters.yaml
+            - --requirements-dir=/workspace/source/
+            - --template-file=jx-auth-configmap.tmpl.yaml
+            - --config-file=templates/jx-auth-configmap.yaml
+            command: jx
+            dir: /workspace/source/systems/jx-auth
+            name: create-jx-auth-config
+          - args:
+            - step
+            - helm
+            - apply
+            - --boot
+            - --remote
+            - --no-vault
+            - --name
+            - jx-auth
+            command: jx
+            dir: /workspace/source/systems/jx-auth
+            name: install-jx-auth-config
+          - args:
+            - step
             - helm
             - apply
             - --boot

--- a/systems/jx-auth/Chart.yaml
+++ b/systems/jx-auth/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+description: Jx Auth Chart
+maintainers:
+- name: Team
+name: jx-auth
+version: "1"

--- a/systems/jx-auth/jx-auth-configmap.tmpl.yaml
+++ b/systems/jx-auth/jx-auth-configmap.tmpl.yaml
@@ -1,0 +1,24 @@
+{{- if eq .Requirements.secretStorage "vault" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jx-auth-config
+  labels:
+    jenkins.io/created-by: jx
+    jenkins.io/config-type: auth
+data:
+  gitAuth.yaml: |
+    currentserver: "{{ .Requirements.cluster.gitServer }}"
+    defaultusername: "{{ .Parameters.pipelineUser.username }}"
+    pipelineserver: "{{ .Requirements.cluster.gitServer }}"
+    pipelineusername: "{{ .Parameters.pipelineUser.username }}"
+    servers:
+    - currentuser: "{{ .Parameters.pipelineUser.username }}"
+      kind: "{{ .Requirements.cluster.gitKind }}"
+      name: "{{ .Requirements.cluster.gitName }}"
+      url: "{{ .Requirements.cluster.gitServer }}"
+      users:
+      - apitoken: "{{ .Parameters.pipelineUser.token }}"
+        bearertoken: ""
+        username: "{{ .Parameters.pipelineUser.username }}"
+{{- end }}

--- a/systems/jx-auth/templates/jx-auth-configmap.yaml
+++ b/systems/jx-auth/templates/jx-auth-configmap.yaml
@@ -1,0 +1,1 @@
+# This jx auth configmap will be generated from template


### PR DESCRIPTION
Also disable the git auth pipeline secret when vault is enabled. This will allow us to avoid duplicating
the git bot token in multiple places. jx will fetch dynamically the token from vault into memory whenever
it needs to authenticate.

The generated and installed config map looks like this:

```
apiVersion: v1
data:
  gitAuth.yaml: |
    currentserver: "https://github.com"
    defaultusername: "ccojocar-bot"
    pipelineserver: "https://github.com"
    pipelineusername: "ccojocar-bot"
    servers:
    - currentuser: "bot-user"
      kind: "github"
      name: "github"
      url: "https://github.com"
      users:
      - apitoken: "vault:cluster-name/pipelineUser:token"
        bearertoken: ""
        username: "bot-user"
kind: ConfigMap
metadata:
  annotations:
    jenkins.io/chart: jx-auth
```
fixes https://github.com/jenkins-x/jx/issues/5114