### PR TITLE
fix: Less confusing wording

### DIFF
--- a/env/parameters.tmpl.schema.json
+++ b/env/parameters.tmpl.schema.json
@@ -98,7 +98,7 @@
     },
     "enableDocker": {
       "type": "boolean",
-      "title": "Do you want to configure an external Docker Registry?",
+      "title": "Do you want to configure non default Docker Registry?",
 {{- if and (ne .Requirements.cluster.provider "gke") (ne .Requirements.cluster.provider "eks") (ne .Requirements.cluster.provider "aks") }}
       "const": true,
 {{- end}}


### PR DESCRIPTION
The current question "Do you want to configure an external Docker Registry?" is confusing. What does external mean? External to what? I interpreted it as external to the cluster, which obviously was wrong in the AWS case.

I think it's better to call it non default. The description then gives some more information.
