### PR TITLE
chore: Pass the pipelineUser token to the Lighthouse chart

### DIFF
--- a/env/lighthouse/values.tmpl.yaml
+++ b/env/lighthouse/values.tmpl.yaml
@@ -29,3 +29,5 @@ vault:
 clusterName: {{ .Requirements.cluster.clusterName }}
 
 user: "{{ .Parameters.pipelineUser.username }}"
+
+oauthToken: "{{ .Parameters.pipelineUser.token }}"


### PR DESCRIPTION
This means that passing whether vault is enabled and the cluster name
don't actually do anything yet - eventually we'll switch to use
vault's mutating webhook and bypass the need for an additional secret,
but for now...

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>