### PR TITLE
fix: toggle nexus ingress using requirements repository configuration

### DIFF
--- a/env/jxboot-resources/values.tmpl.yaml
+++ b/env/jxboot-resources/values.tmpl.yaml
@@ -185,6 +185,13 @@ lighthouse:
   enabled: false
 {{- end }}
 
+nexus:
+{{- if eq .Requirements.repository "nexus" }}
+  enabled: true
+{{- else }}
+  enabled: false
+{{- end }}
+
 prow:
 {{- if eq .Requirements.webhook "prow" }}
   enabled: true


### PR DESCRIPTION
Without this change it seems that if you choose a repository of `bucketrepo` or `none` within `jx-requirements.yml` you're still allocated a nexus ingress