### PR TITLE
fix: allow baremetal cluster to not configure an external registry

### DIFF
--- a/env/parameters.tmpl.schema.json
+++ b/env/parameters.tmpl.schema.json
@@ -99,10 +99,7 @@
     "enableDocker": {
       "type": "boolean",
       "title": "Do you want to configure an external Docker Registry?",
-{{- if and (ne .Requirements.cluster.provider "gke") (ne .Requirements.cluster.provider "eks") (ne .Requirements.cluster.provider "aks") }}
-      "const": true,
-{{- end}}
-      "description": "By default Jenkins X will use the docker registry from the cloud provider. If you want to configure an external docker registry such as Docker Hub or your own existing docker registry enter Y"
+      "description": "By default Jenkins X will use the docker registry from the cloud provider. If you want to configure an external docker registry such as Docker Hub or your own existing public docker registry enter Y"
     }
   },
   "allOf": [


### PR DESCRIPTION
Signed-off-by: Youssef El Houti <youssef.elhouti@gmail.com>

An other PR will be added to documentation to explain that cluster.registry can accept a private registry like: registry.kube-system.svc.cluster.local:5000