### PR TITLE
fix: Get rid of hardcoded gcactivities image and tag

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,6 +10,7 @@ approvers:
 - abayer
 - dgozalo
 - daveconde
+- hferentschik
 reviewers:
 - rawlingsj
 - jstrachan
@@ -22,3 +23,4 @@ reviewers:
 - abayer
 - dgozalo
 - daveconde
+- hferentschik

--- a/env/jenkins-x-platform/values.tmpl.yaml
+++ b/env/jenkins-x-platform/values.tmpl.yaml
@@ -190,9 +190,6 @@ gcactivities:
   cronjob:
     enabled: true
     schedule: "0/30 * * * *"
-  image:
-    repository: gcr.io/jenkinsxio/builder-jx
-    tag: 0.1.658
 
 gcpods:
   cronjob:


### PR DESCRIPTION
These are updated in `jenkins-x-platform` and we should just be
picking up the configuration from there, and we definitely shouldn't
be using an ancient builder image for this.

fixes https://github.com/jenkins-x/jx/issues/6904

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>