### PR TITLE
chore: Switch to Lighthouse as default

### DIFF
--- a/bdd/boot-local/jx-requirements.yml
+++ b/bdd/boot-local/jx-requirements.yml
@@ -36,4 +36,4 @@ storage:
 versionStream:
   ref: "master"
   url: https://github.com/jenkins-x/jenkins-x-versions.git
-webhook: prow
+webhook: lighthouse

--- a/bdd/boot-vault/jx-requirements.yml
+++ b/bdd/boot-vault/jx-requirements.yml
@@ -39,4 +39,4 @@ versionStream:
   url: https://github.com/jenkins-x/jenkins-x-versions.git
 vault:
   disableURLDiscovery: true
-webhook: prow
+webhook: lighthouse

--- a/env/lighthouse/values.tmpl.yaml
+++ b/env/lighthouse/values.tmpl.yaml
@@ -11,13 +11,20 @@ git:
   name: {{ .Requirements.cluster.gitName | default "github" }}
   server: {{ .Requirements.cluster.gitServer | default "https://github.com" }}
 
-service:
-  name: hook
-  
-replicaCount: 2
+webhooks:
+  replicaCount: 2
+  service:
+    name: hook
 
 image:
+  # Deprecated in favor of image.parentRepository but retained for backwards compatibility with old value.
   repository: gcr.io/jenkinsxio/lighthouse
+  parentRepository: gcr.io/jenkinsxio
+
+# Deprecated in favor of webhooks.replicaCount and webhooks.service
+replicaCount: 2
+service:
+  name: hook
 
 vault:
 {{- if eq .Requirements.secretStorage "vault" }}

--- a/jx-requirements.yml
+++ b/jx-requirements.yml
@@ -32,4 +32,4 @@ storage:
 versionStream:
   ref: "master"
   url: https://github.com/jenkins-x/jenkins-x-versions.git
-webhook: prow
+webhook: lighthouse


### PR DESCRIPTION
Also changes the `boot-vault` test context to run with Lighthouse enabled instead of Prow.