### PR TITLE
feat: add ecr permissions to tekton-bot for EKS

### DIFF
--- a/kubeProviders/eks/templates/jenkinsx-policies.yml
+++ b/kubeProviders/eks/templates/jenkinsx-policies.yml
@@ -15,6 +15,7 @@ Resources:
           - cloudformation:DeleteStack
           - eks:*
           - s3:*
+          - ecr:*
           - iam:DetachRolePolicy
           - iam:GetPolicy
           - iam:CreatePolicy


### PR DESCRIPTION
Adding ECR permissions to `tekton-bot` for EKS clusters.

Should fix https://github.com/jenkins-x/jx/issues/7072