### PR TITLE
fix: use the correct kaniko credsStore

### DIFF
--- a/kubeProviders/aks/values.tmpl.yaml
+++ b/kubeProviders/aks/values.tmpl.yaml
@@ -5,7 +5,7 @@ jenkins-x-platform:
     # lets enable ACR docker builds
     DockerConfig: |-
       {
-        "credsStore": "acr-linux"
+        "credsStore": "acr"
       }
     
 docker-registry:


### PR DESCRIPTION
I know because I changed it in https://github.com/GoogleContainerTools/kaniko/pull/1121 :)

error:

```
resolving authorization for **.azurecr.io failed: error getting credentials - err: exec: "docker-credential-acr-linux": executable file not found in $PATH, out: ``
```