### PR TITLE
feat: configure boot for Openshift with restricted permissions

### DIFF
--- a/env/jenkins-x-platform/values.tmpl.yaml
+++ b/env/jenkins-x-platform/values.tmpl.yaml
@@ -181,6 +181,43 @@ controllerbuild:
   - "--verbose"
 {{- end }}
 
+{{- if hasKey .Requirements.cluster "strictPermissions" }}
+{{- if and (eq .Requirements.cluster.provider "openshift") (.Requirements.cluster.strictPermissions) }}
+gcpreviews:
+  clusterrole:
+    enabled: false
+
+postinstalljob:
+  clusterrole:
+    enabled: false
+
+controllerworkflow:
+  clusterrole:
+    enabled: false
+
+controllerbuild:
+  clusterrole:
+    enabled: false
+
+controllercommitstatus:
+  clusterrole:
+    enabled: false
+
+controllerrole:
+  clusterrole:
+    enabled: false
+
+controllerteam:
+  clusterrole:
+    enabled: false
+
+heapster:
+  enabled: false
+  rbac:
+    create: false
+{{- end }}
+{{- end }}
+
 gcactivities:
   args:
     - "gc"
@@ -190,8 +227,20 @@ gcactivities:
   cronjob:
     enabled: true
     schedule: "0/30 * * * *"
+{{- if hasKey .Requirements.cluster "strictPermissions" }}
+{{- if and (eq .Requirements.cluster.provider "openshift") (.Requirements.cluster.strictPermissions) }}
+  clusterrole:
+    enabled: false
+{{- end }}
+{{- end }}
 
 gcpods:
   cronjob:
     enabled: true
     schedule: "0/30 * * * *"
+{{- if hasKey .Requirements.cluster "strictPermissions" }}
+{{- if and (eq .Requirements.cluster.provider "openshift") (.Requirements.cluster.strictPermissions) }}
+  clusterrole:
+    enabled: false
+{{- end }}
+{{- end }}

--- a/env/jxboot-resources/values.tmpl.yaml
+++ b/env/jxboot-resources/values.tmpl.yaml
@@ -25,6 +25,9 @@ cluster:
 {{- if hasKey .Requirements.cluster "provider" }}
   provider:  {{ .Requirements.cluster.provider }}
 {{- end }}
+{{- if hasKey .Requirements.cluster "strictPermissions" }}
+  strictPermissions: {{ .Requirements.cluster.strictPermissions }}
+{{- end }}
   serverUrl: ""
 {{- if .Requirements.ingress.tls.enabled }}
   tls: true

--- a/env/lighthouse/values.tmpl.yaml
+++ b/env/lighthouse/values.tmpl.yaml
@@ -31,3 +31,11 @@ clusterName: {{ .Requirements.cluster.clusterName }}
 user: "{{ .Parameters.pipelineUser.username }}"
 
 oauthToken: "{{ .Parameters.pipelineUser.token }}"
+
+{{- if hasKey .Requirements.cluster "strictPermissions" }}
+{{- if and (eq .Requirements.cluster.provider "openshift") (.Requirements.cluster.strictPermissions) }}
+cluster:
+  crds:
+    create: false
+{{- end }}
+{{- end }}

--- a/env/tekton/values.tmpl.yaml
+++ b/env/tekton/values.tmpl.yaml
@@ -22,3 +22,15 @@ auth:
 {{- end }}
 
 tillerNamespace: ""
+
+{{- if hasKey .Requirements.cluster "strictPermissions" }}
+{{- if and (eq .Requirements.cluster.provider "openshift") (.Requirements.cluster.strictPermissions) }}
+rbac:
+  cluster: false
+cluster:
+  crds:
+    create: false
+  resources:
+    create: false
+{{- end }}
+{{- end }}

--- a/env/values.tmpl.yaml
+++ b/env/values.tmpl.yaml
@@ -6,60 +6,6 @@ tekton:
 {{- else }}
   enabled: false
 {{- end }}
-{{- if eq .Requirements.cluster.provider "openshift" }}
-  rbac:
-    cluster: false
-  cluster:
-    crds:
-      create: false
-    resources:
-      create: false
-{{- end }}
-
-{{- if eq .Requirements.cluster.provider "openshift" }}
-jenkins-x-platform:
-  gcpreviews:
-    clusterrole:
-      enabled: false
-
-  gcactivities:
-    clusterrole:
-      enabled: false
-
-  gcpods:
-    clusterrole:
-      enabled: false
-
-  postinstalljob:
-    clusterrole:
-      enabled: false
-
-  controllerworkflow:
-    clusterrole:
-      enabled: false
-
-  controllerbuild:
-    clusterrole:
-      enabled: false
-
-  controllercommitstatus:
-    clusterrole:
-      enabled: false
-
-  controllerrole:
-    clusterrole:
-      enabled: false
-
-  controllerteam:
-    clusterrole:
-      enabled: false
-
-  heapster:
-    enabled: false
-    rbac:
-      create: false
-{{- end }}
-
 
 # Use cert-manager 0.11 CRDs/APIs with Dex
 dex:


### PR DESCRIPTION
Making changes to a few helm charts so we avoid creating cluster-wide permissions for Openshift when booting with restricted permissions.