### PR TITLE
fix: Ensure we pass a string to the default admin password hashing

### DIFF
--- a/env/jenkins-x-platform/values.tmpl.yaml
+++ b/env/jenkins-x-platform/values.tmpl.yaml
@@ -6,7 +6,7 @@ dockerRegistry: "{{ .Requirements.cluster.registry }}"
 expose:
   enabled: false
 
-JXBasicAuth: "{{ .Parameters.adminUser.username }}:{SHA}{{ .Parameters.adminUser.password | hashPassword }}"
+JXBasicAuth: "{{ .Parameters.adminUser.username }}:{SHA}{{ .Parameters.adminUser.password | toString | hashPassword }}"
 
 cleanup:
   enabled: false


### PR DESCRIPTION
This may not be comprehensive, but it should help with errors like "expected string but got float64".

fixes https://github.com/jenkins-x/jx/issues/7239

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>