### PR TITLE
fix: Use gcr.io/jenkinsxio for nginx-ingress-controller image

### DIFF
--- a/systems/jxing/values.tmpl.yaml
+++ b/systems/jxing/values.tmpl.yaml
@@ -1,5 +1,7 @@
 nginx-ingress:
   controller:
+    image:
+      repository: gcr.io/jenkinsxio/nginx-ingress-controller
     replicaCount: 3
     extraArgs:
       publish-service: kube-system/jxing-nginx-ingress-controller


### PR DESCRIPTION
Now that we've got a cronjob syncing quay.io/kubernetes-ingress-controller/nginx-ingress-controller to gcr.io/jenkinsxio/nginx-ingress-controller twice a day (via https://github.com/jenkins-x/environment-tekton-weasel-dev/pull/602), let's pull the trigger and use that image repo.

fixes https://github.com/jenkins-x/jx/issues/7256

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>