### PR TITLE
feat: add additionalNamespaces to controllerrole

### DIFF
--- a/env/jenkins-x-platform/values.tmpl.yaml
+++ b/env/jenkins-x-platform/values.tmpl.yaml
@@ -204,6 +204,10 @@ controllercommitstatus:
     enabled: false
 
 controllerrole:
+  role:
+    additionalNamespaces:
+    - jx-staging
+    - jx-production
   clusterrole:
     enabled: false
 


### PR DESCRIPTION
After modifying the jx helm chart, we can now apply roles to other namespaces when booting with restricted permissions.