### PR TITLE
feat: add manifests to be used when installing Jenkins X on a restricted permissions openshift cluster

### DIFF
--- a/kubeProviders/openshift/templates/README.md
+++ b/kubeProviders/openshift/templates/README.md
@@ -1,0 +1,11 @@
+## Openshift Manifests
+
+The files in this folder will never be applied automatically by Jenkins X and are here just to be used independently or to be referenced in documentation.
+
+One of the steps to get Jenkins X installed in an OpenShift cluster with limited permissions is having an admin install these manifests in the cluster directly with Kubectl.
+
+By having them here, they can do so by executing:
+
+```bash
+ $ kubectl -f https://raw.githubusercontent.com/<path_to_the_file>
+```

--- a/kubeProviders/openshift/templates/controller-build-scc.yaml
+++ b/kubeProviders/openshift/templates/controller-build-scc.yaml
@@ -1,0 +1,33 @@
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: []
+apiVersion: v1
+defaultAddCapabilities: []
+fsGroup:
+  type: MustRunAs
+kind: SecurityContextConstraints
+metadata:
+  name: scc-jx-controllerbuild
+priority: 1
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- KILL
+- MKNOD
+- SETUID
+- SETGID
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:jx:jenkins-x-controllerbuild
+volumes:
+- secret
+

--- a/kubeProviders/openshift/templates/jx-admin-role.yaml
+++ b/kubeProviders/openshift/templates/jx-admin-role.yaml
@@ -1,0 +1,41 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: jx
+  name: jx-admin
+rules:
+- apiGroups:
+  - '*'
+  attributeRestrictions: null
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: jx-staging
+  name: jx-admin
+rules:
+- apiGroups:
+  - '*'
+  attributeRestrictions: null
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---  
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: jx-production
+  name: jx-admin
+rules:
+- apiGroups:
+  - '*'
+  attributeRestrictions: null
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/kubeProviders/openshift/templates/namespaces.yaml
+++ b/kubeProviders/openshift/templates/namespaces.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jx
+  labels:
+    jenkins.io/created-by: "jx-boot"
+    env: "dev"
+    team: "jx"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jx-staging
+  labels:
+    jenkins.io/created-by: "jx-boot"
+    env: "staging"
+    team: "jx"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jx-production
+  labels:
+    jenkins.io/created-by: "jx-boot"
+    env: "production"
+    team: "jx"

--- a/kubeProviders/openshift/templates/service-accounts.yaml
+++ b/kubeProviders/openshift/templates/service-accounts.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jenkins-x-bucketrepo
+  namespace: jx
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jenkins-x-controllerbuild
+  namespace: jx
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jenkins-x-controllerrole
+  namespace: jx
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jenkins-x-gcactivities
+  namespace: jx
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jenkins-x-gcpods
+  namespace: jx
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jenkins-x-gcpreviews
+  namespace: jx
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jenkins-x-heapster
+  namespace: jx
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jenkins
+  namespace: jx
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jenkins-x-lighthouse
+  namespace: jx
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tide
+  namespace: jx
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-pipelines
+  namespace: jx
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-bot
+  namespace: jx
+

--- a/kubeProviders/openshift/templates/tekton-crds.yaml
+++ b/kubeProviders/openshift/templates/tekton-crds.yaml
@@ -1,0 +1,227 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clustertasks.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: ClusterTask
+    plural: clustertasks
+    categories:
+    - all
+    - tekton-pipelines
+  scope: Cluster
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: conditions.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: Condition
+    plural: conditions
+    categories:
+      - all
+      - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: images.caching.internal.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
+spec:
+  group: caching.internal.knative.dev
+  version: v1alpha1
+  names:
+    kind: Image
+    plural: images
+    singular: image
+    categories:
+    - knative-internal
+    - caching
+    shortNames:
+    - img
+  scope: Namespaced
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelines.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: Pipeline
+    plural: pipelines
+    categories:
+    - all
+    - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineruns.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: PipelineRun
+    plural: pipelineruns
+    categories:
+    - all
+    - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineresources.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: PipelineResource
+    plural: pipelineresources
+    categories:
+    - all
+    - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tasks.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: Task
+    plural: tasks
+    categories:
+    - all
+    - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: taskruns.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: TaskRun
+    plural: taskruns
+    categories:
+    - all
+    - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: jx-tekton
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+  - 'emptyDir'
+  - 'configMap'
+  - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-pipelines
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "secrets", "events", "serviceaccounts", "configmaps", "persistentvolumeclaims"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/finalizers"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["tasks/status", "clustertasks/status", "taskruns/status", "pipelines/status", "pipelineruns/status", "pipelineresources/status"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["tasks", "clustertasks", "taskruns", "pipelines", "pipelineruns", "pipelineresources", "conditions"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["taskruns/finalizers", "pipelineruns/finalizers"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["tekton-pipelines"]
+    verbs: ["use"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name:  tekton-pipelines-jx
+subjects:
+  - kind: ServiceAccount
+    name: tekton-pipelines
+    namespace: jx
+roleRef:
+  kind: ClusterRole
+  name:  tekton-pipelines
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
These files will not be applied directly by Jenkins X but they will be stored to be applied with kubectl manually:

`kubectl apply -f https://raw.githubusercontent.com/jenkins-x/jenkins-x-boot-config/master/kubeProviders/openshift/templates/...`
