### PR TITLE
feat: add docker config for external registries for Kubernetes and AKS

### DIFF
--- a/kubeProviders/aks/values.tmpl.yaml
+++ b/kubeProviders/aks/values.tmpl.yaml
@@ -2,11 +2,24 @@
 jenkins-x-platform:
   PipelineSecrets:
 
+{{- if eq .Parameters.enableDocker true }}
+    DockerConfig: |-
+      {
+        "auths":{
+          {{ .Parameters.docker.url | quote }}:
+            {
+              "auth": {{ printf "%s:%s" .Parameters.docker.username .Parameters.docker.password | b64enc | quote}},
+              "email": {{ .Parameters.docker.email | quote}}
+            }
+        }
+      }
+{{- else}}
     # lets enable ACR docker builds
     DockerConfig: |-
       {
         "credsStore": "acr"
       }
-    
+{{- end}}
+
 docker-registry:
   enabled: false    

--- a/kubeProviders/kubernetes/values.tmpl.yaml
+++ b/kubeProviders/kubernetes/values.tmpl.yaml
@@ -1,1 +1,16 @@
 # Override configuration from https://github.com/jenkins-x/jenkins-x-platform/blob/master/jenkins-x-platform/values.yaml
+jenkins-x-platform:
+  PipelineSecrets:
+
+{{- if eq .Parameters.enableDocker true }}
+    DockerConfig: |-
+      {
+        "auths":{
+          {{ .Parameters.docker.url | quote }}:
+            {
+              "auth": {{ printf "%s:%s" .Parameters.docker.username .Parameters.docker.password | b64enc | quote}},
+              "email": {{ .Parameters.docker.email | quote}}
+            }
+        }
+      }
+{{- end}}


### PR DESCRIPTION
This is necessary to let users connect to an external docker registry with vanilla Kubernetes / AKS.