### PR TITLE
fix(pencil): Fixed Velero values for AKS boot

### DIFF
--- a/systems/velero/values.tmpl.yaml
+++ b/systems/velero/values.tmpl.yaml
@@ -42,7 +42,7 @@ velero:
       bucket: {{ .Requirements.storage.backup.url | removeScheme | quote }}
       config:
         region: {{ .Requirements.cluster.region | quote }}
-{{- else if eq .Requirements.cluster.provider "aks" }}
+{{- else if and (eq .Requirements.cluster.provider "aks") (hasKey .Requirements.velero "namespace") }}
   initContainers:
   - name: velero-plugin-for-azure
     image: velero/velero-plugin-for-microsoft-azure:v1.0.0
@@ -54,9 +54,10 @@ velero:
     provider: azure
     backupStorageLocation:
       name: azure
-      bucket: {{ .Requirements.storage.backup.url | removeScheme | quote }}
+      bucket: {{ .Requirements.velero.bucketName | removeScheme | quote }}
       config:
         storageAccount: {{ .Requirements.velero.serviceAccount | quote }}
+        resourceGroup: {{ .Requirements.velero.resourceGroup | quote }}
 {{- else if eq .Requirements.cluster.provider "iks" }}
   initContainers:
   - name: velero-plugin-for-aws


### PR DESCRIPTION
Ensured initContainers in Velero values are only outputted if a namespace is defined for Velero for AKS.

Currently a `jx boot` for AKS only succeeds if a service account for Velero is specified in the requirements file. This is due to `omitempty` being specified on the type/schema generation for RequirementsConfig. This solution ensures that we do not provision initContainers where we do not have velero enabled. With initContainers not being deployed we avoid the `jx boot` issues around trying to select requirements that do not exist in the requirements file. 

My rationale for this solution rather than fixing up json serialisation (i.e. remove `omitempty`) is that we should not be enforcing outputting velero requirements if we do not intend to utilise velero in cluster. Equally we should not be outputting initContainer values if we do not intend to use velero either. This PR could be widen up to cover all cloud providers if consensus says there is wider benefit.

Will resolve jenkins-x/jx#7483