### PR TITLE
feat(pencil): Added in external dns secret name for Azure DNS provider

### DIFF
--- a/systems/external-dns/values.tmpl.yaml
+++ b/systems/external-dns/values.tmpl.yaml
@@ -15,6 +15,10 @@ external-dns:
  {{- if hasKey .Requirements.cluster "project" }}
     project: "{{ .Requirements.cluster.project }}"
  {{ end }}
+{{- else if eq .Requirements.cluster.provider "aks"}}
+  provider: azure
+  azure:
+    secretName: azure-external-dns-secret
 {{- end}}
 
   rbac:


### PR DESCRIPTION
Currently boot config doesn't make provisions for an Azure DNS provider. This PR basically configures the provider to be Azure DNS if the cluster is AKS. Sets the secret name to a well known secret that will be provisioned via terraform jx azurerm module.