### PR TITLE
chore: Add lighthouse-jx

### DIFF
--- a/env/lighthouse-jx/README.MD
+++ b/env/lighthouse-jx/README.MD
@@ -1,0 +1,6 @@
+# lighthouse-jx
+
+|App Metadata||
+|---|---|
+| **Version** | 0.0.2 |
+| **Chart Repository** | http://chartmuseum.jenkins-x.io |

--- a/env/lighthouse-jx/values.tmpl.yaml
+++ b/env/lighthouse-jx/values.tmpl.yaml
@@ -1,0 +1,5 @@
+{{- if eq .Requirements.webhook "lighthouse" }}
+enabled: true
+  {{- else }}
+enabled: false
+  {{- end }}

--- a/env/lighthouse/values.tmpl.yaml
+++ b/env/lighthouse/values.tmpl.yaml
@@ -46,3 +46,7 @@ cluster:
     create: false
 {{- end }}
 {{- end }}
+
+# Disable the legacy jx controller in favor of lighthouse-jx's.
+engines:
+  jx: false

--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,6 +12,10 @@ dependencies:
   condition: lighthouse.enabled
   name: lighthouse
   repository: http://chartmuseum.jenkins-x.io
+- alias: lighthouse-jx
+  condition: lighthouse.enabled
+  name: lighthouse-jx
+  repository: http://chartmuseum.jenkins-x.io
 - alias: bucketrepo
   condition: bucketrepo.enabled
   name: bucketrepo


### PR DESCRIPTION
Part of https://github.com/jenkins-x/lighthouse/issues/867. This will switch to using https://github.com/jenkins-x/lighthouse-jx-controller instead of the `lighthouse-jx-controller` currently in the `lighthouse` chart (which will be removed once this has made it into the version stream).

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>