### PR TITLE
fix: Update controller-build-scc.yaml

### DIFF
--- a/kubeProviders/openshift/templates/controller-build-scc.yaml
+++ b/kubeProviders/openshift/templates/controller-build-scc.yaml
@@ -6,7 +6,7 @@ allowHostPorts: false
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: false
 allowedCapabilities: []
-apiVersion: v1
+apiVersion: security.openshift.io/v1
 defaultAddCapabilities: []
 fsGroup:
   type: MustRunAs


### PR DESCRIPTION
Use security.openshift.io/v1 instead of v1 to fix no matches for kind "SecurityContextConstraints" in version "v1" for OpenShift.