### PR TITLE
fix: update github token validation to match the new changes in the p…

### DIFF
--- a/env/parameters.tmpl.schema.json
+++ b/env/parameters.tmpl.schema.json
@@ -51,8 +51,8 @@
           "title": "Pipeline bot Git token",
           "description": "A token for the Git user that will perform git operations inside a pipeline. This includes environment repository creation, and so this token should have full repository permissions. To create a token go to {{ .GitServer }}/settings/tokens/new?scopes=repo,read:user,read:org,user:email,write:repo_hook,delete_repo then enter a name, click Generate token, and copy and paste the token into this prompt.",
           "minLength": 40,
-          "maxLength": 40,
-          "pattern": "^[0-9a-f]{40}$"
+          "maxLength": 255,
+          "pattern": "^[A-Za-z0-9_]{40,255}$"
         }
 {{- else if eq .GitKind "bitbucketserver" }}
         "token": {


### PR DESCRIPTION
This is a simple fix so the GitHub Token Validation can pass.

The actual `jx boot` validation rules expect the GitHub token to be hexadecimal and 40 characters long. This is no longer the case because GitHub tokens have changed. Please check the link below and the image.

[Authentication token format updates](https://github.blog/changelog/2021-03-31-authentication-token-format-updates-are-generally-available/)

<img width="753" alt="personal_access_tokens" src="https://user-images.githubusercontent.com/8235254/113740572-d1125100-96ce-11eb-8877-d84e174a6e05.png">